### PR TITLE
Add role group functionality

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -138,6 +138,46 @@ declare global {
 
     });
 
+    bot.on("guildMemberUpdate", async (guild, member, oldMember) => {
+
+      try {
+
+        // Make sure we have the old member.
+        if (!oldMember) return;
+
+        // Check if the member obtained a new role.
+        const newRoles = member.roles;
+        for (let i = 0; newRoles.length > i; i++) {
+
+          const roleId = newRoles[i];
+          if (!oldMember.roles.find((possibleRoleId) => possibleRoleId === roleId)) {
+
+            // Check if the new role is the base of a role group.
+            const roleGroup = await collections.roleGroups.findOne({baseRoleId: roleId});
+            if (roleGroup) {
+
+              // Give the member some more roles.
+              const {attachedRoleIds} = roleGroup;
+              for (let i = 0; attachedRoleIds.length > i; i++) {
+
+                await member.addRole(attachedRoleIds[i], "Following a role group rule");
+
+              }
+
+            }
+
+          }
+
+        }
+
+      } catch (err: any) {
+
+        console.log(err);
+
+      }
+
+    });
+
     const botId = bot.user.id;
     async function getUserMemberAndBotMember(guild: Guild, userId: string): Promise<{userMember?: Member, botMember?: Member}> {
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,8 +28,7 @@ declare global {
   const db = dbClient.db("guilds");
   const collections = {
     autoRoles: db.collection("AutoRoles"),
-    interactions: db.collection("Interactions"),
-    questions: db.collection("Questions")
+    roleGroups: db.collection("roleGroups")
   };
 
   console.log("\x1b[32m%s\x1b[0m", "[Client] Database variables updated");

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -184,6 +184,10 @@ async function storeClientAndCollections(discordClient: Client, collections: {[n
   
       }
 
+    } else if (interaction.type === 3) {
+
+      
+
     }
 
   });

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptions, Client, CommandInteraction, ComponentInteraction, EventListeners } from "eris";
+import { ApplicationCommandOptions, ApplicationCommandStructure, Client, CommandInteraction, ComponentInteraction, EventListeners } from "eris";
 import { Collection } from "mongodb";
 
 const commands: {[name: string]: Command} = {};
@@ -157,6 +157,66 @@ class Command {
       console.log("\x1b[36m%s\x1b[0m", "[Commands] Removing interaction for command \"" + this.name + "\"...");
       this.deleteInteractionOnFirstUsage = true;
       console.log("\x1b[32m%s\x1b[0m", "[Commands] Removed interaction for command \"" + this.name + "\"...");
+
+    } else if (this.slashOptions && interactionCmdInfo && interactionCmdInfo.type === 1) {
+
+      const updateCommand = async () => {
+
+        console.log("\x1b[36m%s\x1b[0m", `[Commands] Updating ${this.name} command...`);
+
+        await _discordClient.editCommand(interactionCmdInfo.id, {
+          name: this.name,
+          description: this.description,
+          options: this.slashOptions
+        } as Omit<ApplicationCommandStructure, "type">);
+
+      };
+
+      // Now, we can run the loop.
+      type ObjectWithStringIndex = {[index: string]: any};
+      // eslint-disable-next-line no-unused-vars
+      const deepEqual: (object1: ObjectWithStringIndex | any[], object2: ObjectWithStringIndex | any[]) => boolean = (object1: ObjectWithStringIndex | any[], object2: ObjectWithStringIndex | any[]) => {
+
+        const object1Keys = Object.keys(object1);
+        for (let i = 0; object1Keys.length > i; i++) {
+
+          const key = object1Keys[i];
+          const object1IsArray = Array.isArray(object1);
+          const object2IsArray = Array.isArray(object2);
+          const value1 = object1IsArray ? object1[parseInt(key, 10)] : object1[key];
+          const value2 = object2IsArray ? object2[parseInt(key, 10)] : object2[key];
+          if (value1 !== value2) {
+
+            // Check if it's an object or an array.
+            const value1IsArray = Array.isArray(value1);
+            const value2IsArray = Array.isArray(value2);
+            if ((value1IsArray && value2IsArray) || (!value1IsArray && !value2IsArray && (value1 instanceof Object && value2 instanceof Object))) {
+              
+              if (!deepEqual(value1, value2)) {
+
+                return false;
+
+              }
+
+            } else {
+
+              return false;
+
+            }
+
+          }
+
+        }
+
+        return true;
+
+      };
+      
+      if (!deepEqual(this.slashOptions, interactionCmdInfo.options)) {
+
+        await updateCommand();
+        
+      }
 
     }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -15,7 +15,8 @@ export interface CommandActionProperties {
 interface CommandProperties {
   name: string;
   description: string;
-  action: Function;
+  // eslint-disable-next-line no-unused-vars
+  action: ({discordClient, collections, interaction}: CommandActionProperties) => void;
   slashOptions?: ApplicationCommandOptions[];
   cooldown?: number;
   ephemeral?: boolean;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -16,7 +16,7 @@ interface CommandProperties {
   name: string;
   description: string;
   // eslint-disable-next-line no-unused-vars
-  action: ({discordClient, collections, interaction}: CommandActionProperties) => void;
+  action: (props: CommandActionProperties) => Promise<void>;
   slashOptions?: ApplicationCommandOptions[];
   cooldown?: number;
   ephemeral?: boolean;

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -6,38 +6,43 @@ new Command({
   // eslint-disable-next-line no-unused-vars
   action: async ({discordClient, collections, interaction}: CommandActionProperties) => {
 
-    // Make sure they're allowed to eval
-    if ((interaction.member || interaction.user).id !== "419881371004174338") {
+    // Make sure this is a command interaction.
+    if (interaction.type === 2) {
+
+      // Make sure they're allowed to eval
+      if ((interaction.member || interaction.user).id !== "419881371004174338") {
+        
+        await interaction.createFollowup("I don't think I want to do that.");
+        return;
+
+      }
       
-      await interaction.createFollowup("I don't think I want to do that.");
-      return;
+      // Make sure we have a code string.
+      const code = interaction.data.options?.find(option => option.name === "code")?.value;
+      if (typeof code !== "string") {
 
-    }
-    
-    // Make sure we have a code string.
-    const code = interaction.data.options?.find(option => option.name === "code")?.value;
-    if (typeof code !== "string") {
+        await interaction.createFollowup("You need to ");
+        return;
+        
+      }
 
-      await interaction.createFollowup("You need to ");
-      return;
-      
-    }
+      try {
 
-    try {
+        // Run the code.
+        eval(code);
 
-      // Run the code.
-      eval(code);
+        // End the interaction with a response.
+        await interaction.createFollowup("Done!");
 
-      // End the interaction with a response.
-      await interaction.createFollowup("Done!");
+      } catch (err: any) {
 
-    } catch (err: any) {
+        // Return the error.
+        await interaction.createFollowup({
+          content: err.message,
+          embeds: [{description: err.stack}]
+        });
 
-      // Return the error.
-      await interaction.createFollowup({
-        content: err.message,
-        embeds: [{description: err.stack}]
-      });
+      }
 
     }
 

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -7,14 +7,20 @@ new Command({
   action: async ({discordClient, collections, interaction}: CommandActionProperties) => {
 
     // Make sure they're allowed to eval
-    if ((interaction.member || interaction.user).id !== "419881371004174338") return await interaction.createFollowup("I don't think I want to do that.");
+    if ((interaction.member || interaction.user).id !== "419881371004174338") {
+      
+      await interaction.createFollowup("I don't think I want to do that.");
+      return;
+
+    }
     
     // Make sure we have a code string.
     const code = interaction.data.options?.find(option => option.name === "code")?.value;
     if (typeof code !== "string") {
 
-      return await interaction.createFollowup("You need to ");
-
+      await interaction.createFollowup("You need to ");
+      return;
+      
     }
 
     try {
@@ -23,12 +29,12 @@ new Command({
       eval(code);
 
       // End the interaction with a response.
-      return await interaction.createFollowup("Done!");
+      await interaction.createFollowup("Done!");
 
     } catch (err: any) {
 
       // Return the error.
-      return await interaction.createFollowup({
+      await interaction.createFollowup({
         content: err.message,
         embeds: [{description: err.stack}]
       });

--- a/src/commands/groups.ts
+++ b/src/commands/groups.ts
@@ -1,0 +1,73 @@
+import { Role } from "eris";
+import { Command } from "../commands.js";
+
+new Command({
+  name: "groups",
+  description: "Configure role groups",
+  cooldown: 0,
+  slashOptions: [
+    {
+      name: "create",
+      description: "Creates a role group",
+      type: 1,
+      options: [
+        {
+          name: "base",
+          description: "If this role is given...",
+          type: 8,
+          required: true
+        }
+      ]
+    },
+    {
+      name: "delete",
+      description: "Deletes a role group",
+      type: 1,
+      options: [
+        {
+          name: "base",
+          description: "If this role is given...",
+          type: 8,
+          required: true
+        }
+      ]
+    }
+  ],
+  action: async ({discordClient, collections, interaction}) => {
+
+    // Verify that we're in a text channel.
+    if (!("guild" in interaction.channel)) {
+      
+      await interaction.createFollowup("You can only run this command in a guild!");
+      return;
+      
+    }
+
+    // Verify the guild member.
+    const {guild} = interaction.channel;
+    const member = guild.members.find(possibleMember => possibleMember.id === interaction.member?.user.id);
+    if (!member) {
+      
+      await interaction.createFollowup("I can't find you in the guild member list!");
+      return;
+
+    }
+
+    // Make sure they have permission to manage roles.
+    if (!member.permissions.has("manageRoles")) {
+
+      await interaction.createFollowup("Unfortunately, I can't do that. You don't have permission to manage roles.");
+      return;
+
+    }
+
+    // Present the list of server roles to them.
+    const selectedRoles: Role[] = [];
+    while (!selectedRoles[0]) {
+
+    }
+    const {roles} = guild;
+
+
+  }
+});

--- a/src/commands/groups.ts
+++ b/src/commands/groups.ts
@@ -1,14 +1,14 @@
-import { InteractionDataOptionsSubCommand, Role, SelectMenuOptions } from "eris";
+import { InteractionDataOptionsSubCommand, Message, Role, SelectMenuOptions } from "eris";
 import { Command } from "../commands.js";
 
-interface MenuDataProperties {
-  [guildId: string]: {
-    page: number;
-    selectedRoles: Role[];
+interface ActiveInteractions {
+  [messageId: string]: {
+    selectedRoleIds: string[];
+    latestActionTime: number;
   }
 }
 
-const menuData: MenuDataProperties = {};
+const activeInteractions: ActiveInteractions = {};
 
 new Command({
   name: "groups",
@@ -46,7 +46,7 @@ new Command({
 
     // Verify that we're in a text channel.
     if (!("guild" in interaction.channel)) {
-      
+        
       await interaction.createFollowup("You can only run this command in a guild!");
       return;
       
@@ -62,23 +62,6 @@ new Command({
 
     }
 
-    // Verify that we have a base role.
-    const subCommand = interaction.data.options?.find((option) => option.type === 1) as InteractionDataOptionsSubCommand;
-    if (!subCommand) {
-
-      await interaction.createFollowup("Couldn't find sub-command.");
-      return;
-
-    }
-
-    const baseRole = subCommand.options?.find((option) => option.name === "base")?.value;
-    if (!baseRole) {
-      
-      await interaction.createFollowup("You didn't give me a role to work with!");
-      return;
-
-    }
-
     // Make sure they have permission to manage roles.
     if (!member.permissions.has("manageRoles")) {
 
@@ -87,88 +70,386 @@ new Command({
 
     }
 
+    // Get the bot's highest role.
+    const botMember = guild.members.find(possibleMember => possibleMember.id === discordClient.user.id);
+    if (!botMember) {
+      
+      await interaction.createFollowup("I can't find myself on the guild member list!");
+      return;
+
+    }
+    let highestRolePosition: number = 0;
+    for (let i = 0; botMember.roles.length > i; i++) {
+
+      // Get the role position from the guild.
+      const roleId = botMember.roles[i];
+      const role = guild.roles.find((possibleRole) => possibleRole.id === roleId);
+      if (!role) continue;
+      if (highestRolePosition < role.position) highestRolePosition = role.position;
+
+    }
+
+ 
     // Make sure there is at least one role in the guild.
-    let roles = guild.roles.filter(() => true);
+    let roles: Role[] = guild.roles.filter((role: Role) => !role.managed && role.position < highestRolePosition);
     if (roles.length === 0) {
 
-      await interaction.createFollowup("There aren't any roles in this server!");
+      await interaction.createFollowup("There aren't any non-managed roles in this server!");
       return;
 
     }
 
-    // Present the roles to the user.
-    let selectMenuOptions: SelectMenuOptions[] = [];
-    for (let i = 0; roles.length >= i; i++) {
+    // Order the roles by their current order.
+    roles = roles.sort((roleA: Role, roleB: Role) => roleB.position - roleA.position);
 
-      const {name, id} = roles[i];
-      selectMenuOptions[i] = {
-        label: name,
-        value: id
+    // Find out if the member already has a menu open.
+    if (interaction.type === 2) {
+
+      // This is a command interaction, so the menu hasn't been created.
+      // Verify that we have a base role.
+      const subCommand: InteractionDataOptionsSubCommand = interaction.data.options?.find((option) => option.type === 1) as InteractionDataOptionsSubCommand;
+      if (!subCommand) {
+
+        await interaction.createFollowup("Couldn't find sub-command.");
+        return;
+
+      }
+
+      const baseRole: string | number | boolean | undefined = subCommand.options?.find((option) => option.name === "base")?.value;
+      if (!baseRole) {
+        
+        await interaction.createFollowup("You didn't give me a role to work with!");
+        return;
+
+      }
+
+      // Present the roles to the user.
+      let selectMenuOptions: SelectMenuOptions[] = [];
+      let canGoForward = false;
+      for (let i = 0; roles.length >= i; i++) {
+
+        if (selectMenuOptions.length === 25) {
+
+          canGoForward = true;
+          break;
+
+        }
+
+        const {name, id} = roles[i];
+        selectMenuOptions.push({
+          label: name,
+          value: id
+        });
+
+      }
+
+      const followup = await interaction.createFollowup({
+        content: `What roles do you want to associate with <@&${baseRole}>?`,
+        components: [
+          {
+            type: 1, 
+            components: [
+              {
+                type: 3,
+                custom_id: "menu",
+                options: selectMenuOptions,
+                min_values: 0,
+                max_values: selectMenuOptions.length
+              }
+            ]
+          },
+          {
+            type: 1,
+            components: [
+              {
+                type: 2,
+                label: "Previous page",
+                style: 2,
+                custom_id: "previous",
+                disabled: true
+              },
+              {
+                type: 2,
+                label: "Page 1",
+                style: 2,
+                custom_id: "page",
+                disabled: true
+              },
+              {
+                type: 2,
+                label: "Next page",
+                style: 2,
+                custom_id: "next",
+                disabled: !canGoForward
+              }
+            ]
+          },
+          {
+            type: 1,
+            components: [
+              {
+                type: 2,
+                label: "Create role group",
+                style: 3,
+                custom_id: "submit",
+                disabled: true
+              }
+            ]
+          }
+        ]
+      });
+
+      activeInteractions[followup.id] = {
+        latestActionTime: new Date().getTime(),
+        selectedRoleIds: []
       };
 
-      if (selectMenuOptions.length === 25) break;
+    } else if (interaction.type === 3) {
+
+      // This is a component interaction, so the menu is open.
+      // Get the current page.
+      const originalMessage = interaction.message;
+
+      // Check if the member wants to change the page or submit.
+      const {custom_id} = interaction.data;
+      switch (custom_id) {
+
+        case "previous":
+        case "next": {
+          
+          // Calculate the new page number.
+          const pageComponent = originalMessage.components?.[1].components?.[1];
+          const currentPageNumber = pageComponent?.type === 2 && pageComponent.label ? parseInt(pageComponent.label.slice(5), 10) : 1;
+          const newPageNumber = currentPageNumber + (custom_id === "next" ? 1 : -1);
+
+          // Iterate through the roles, and start on the new page number.
+          let selectMenuOptions: SelectMenuOptions[] = [];
+          let canGoForward = false;
+          const {selectedRoleIds} = activeInteractions[originalMessage.id];
+          for (let i = (newPageNumber - 1) * 24; roles.length > i; i++) {
+
+            if (selectMenuOptions.length === 25) {
+
+              canGoForward = true;
+              break;
+
+            }
+
+            const {name, id} = roles[i];
+            selectMenuOptions.push({
+              label: name,
+              value: id,
+              default: selectedRoleIds.find((possibleId) => possibleId === id) ? true : false
+            });
+
+          }
+
+          // Check if there are roles not shown.
+          let embed: Message["embeds"][0] | undefined;
+          for (let i = 0; selectedRoleIds.length > i; i++) {
+
+            const id = selectedRoleIds[i];
+            if (!selectMenuOptions.find((possibleId) => possibleId.value === id)) {
+
+              const roleMentionString = `<@&${id}>`;
+              if (embed) {
+
+                embed.description += `, ${roleMentionString}`;
+
+              } else {
+
+                embed = {
+                  type: "rich",
+                  title: "Roles that you selected, but aren't listed:",
+                  description: roleMentionString
+                };
+
+              }
+
+            }
+
+          }
+
+          // Update the original followup.
+          await interaction.message.edit({
+            content: interaction.message.content,
+            embeds: embed ? [embed] : [],
+            components: [
+              {
+                type: 1,
+                components: [
+                  {
+                    type: 3,
+                    custom_id: "menu",
+                    options: selectMenuOptions,
+                    min_values: 0,
+                    max_values: selectMenuOptions.length
+                  }
+                ]
+              },
+              {
+                type: 1,
+                components: [
+                  {
+                    type: 2,
+                    label: "Previous page",
+                    style: 2,
+                    custom_id: "previous",
+                    disabled: newPageNumber === 1
+                  },
+                  {
+                    type: 2,
+                    label: `Page ${newPageNumber}`,
+                    style: 2,
+                    custom_id: "page",
+                    disabled: true
+                  },
+                  {
+                    type: 2,
+                    label: "Next page",
+                    style: 2,
+                    custom_id: "next",
+                    disabled: !canGoForward
+                  },
+                ]
+              },      
+              {
+                type: 1,
+                components: [
+                  {
+                    type: 2,
+                    label: "Create role group",
+                    style: 3,
+                    custom_id: "submit",
+                    disabled: activeInteractions[originalMessage.id].selectedRoleIds[0] ? false : true
+                  }
+                ]
+              }
+            ]
+          });
+
+          break;
+
+        }
+
+        case "submit": {
+
+          // Save the list of roles to the database.
+          const {selectedRoleIds} = activeInteractions[originalMessage.id];
+          const baseRoleId = originalMessage.content.match(/<@&\d+>/gm)?.[0].match(/\d+/gm)?.[0];
+          if (!baseRoleId) return;
+          await collections.roleGroups.updateOne(
+            {baseRoleId}, 
+            {
+              $set: {
+                baseRoleId,
+                attachedRoleIds: selectedRoleIds
+              }
+            }, 
+            {upsert: true}
+          );
+
+          // And we're done!
+          await originalMessage.edit({
+            content: `Attached the following roles to <@&${baseRoleId}>: <@&${selectedRoleIds.join(">, <@&")}>`,
+            embeds: [],
+            components: []
+          });
+
+          break;
+
+        }
+
+        case "menu": {
+
+          const endInteractionWithError: () => Promise<void> = async () => {
+
+            await interaction.message.delete();
+            return;
+
+          };
+
+          // Make sure we have options.
+          const selectMenu = originalMessage.components?.[0].components?.[0];
+          const options = selectMenu && "options" in selectMenu ? selectMenu.options : undefined;
+          if (!selectMenu || !options) return endInteractionWithError();
+
+          // Make sure we have values.
+          const rolesInSelectMenu = "values" in interaction.data ? interaction.data.values : undefined;
+          if (!rolesInSelectMenu) return endInteractionWithError();
+
+          // Make sure the interaction was recorded.
+          if (!activeInteractions[originalMessage.id]) return endInteractionWithError();
+
+          for (let i = 0; options.length > i; i++) {
+
+            const currentRoleId = options[i].value;
+            const possibleIdChecker = (possibleId: string): boolean => possibleId === currentRoleId;
+
+            // Check if the member wants to add or remove a role from the role group.
+            const isRoleInSelectMenu = rolesInSelectMenu.find(possibleIdChecker);
+            if (isRoleInSelectMenu) {
+
+              // Add the role ID to the selected role list.
+              activeInteractions[originalMessage.id].selectedRoleIds.push(currentRoleId);
+              options[i].default = true;
+
+            } else if (activeInteractions[originalMessage.id].selectedRoleIds.find(possibleIdChecker)) {
+
+              // Remove the role ID from the selected role list.
+              activeInteractions[originalMessage.id].selectedRoleIds = activeInteractions[originalMessage.id].selectedRoleIds.filter((possibleId) => !possibleIdChecker(possibleId));
+              options[i].default = false;
+
+            } 
+
+          }
+
+          // Check if the submit button status needs to changed.
+          const submitButtonDisabled = originalMessage?.components?.[2].components?.[0].disabled;
+          const isSelectingAtLeastOne = activeInteractions[originalMessage.id].selectedRoleIds[0] ? true : false;
+          const shouldBeDisabled = !submitButtonDisabled && !isSelectingAtLeastOne;
+          if ((submitButtonDisabled && isSelectingAtLeastOne) || shouldBeDisabled) {
+
+            await originalMessage.edit({
+              content: originalMessage.content,
+              components: [
+                {
+                  type: 1,
+                  components: [
+                    {
+                      type: 3,
+                      custom_id: "menu",
+                      options,
+                      min_values: 0,
+                      max_values: options.length
+                    }
+                  ]
+                },
+                originalMessage.components![1],
+                {
+                  type: 1,
+                  components: [
+                    {
+                      ...originalMessage.components![2].components[0],
+                      disabled: shouldBeDisabled
+                    }
+                  ]
+                }
+              ]
+            });
+
+          }
+          break;
+
+        }
+
+        default:
+          break;
+
+      }
 
     }
 
-    await interaction.createFollowup({
-      content: `What roles do you want to associate with <@&${baseRole}>?`,
-      embeds: [
-        {
-          description: "As you select roles, I'll add them to this list!"
-        }
-      ],
-      components: [
-        {
-          type: 1, 
-          components: [
-            {
-              type: 3,
-              custom_id: "menu-test",
-              options: selectMenuOptions,
-              min_values: 1,
-              max_values: 25
-            }
-          ]
-        },
-        {
-          type: 1,
-          components: [
-            {
-              type: 2,
-              label: "Previous page",
-              style: 2,
-              custom_id: "previous",
-              disabled: true
-            },
-            {
-              type: 2,
-              label: "Page 1",
-              style: 2,
-              custom_id: "submit",
-              disabled: true
-            },
-            {
-              type: 2,
-              label: "Next page",
-              style: 2,
-              custom_id: "next",
-              disabled: true
-            }
-          ]
-        },
-        {
-          type: 1,
-          components: [
-            {
-              type: 2,
-              label: "Create role group",
-              style: 2,
-              custom_id: "submit"
-            }
-          ]
-        }
-      ]
-    });
-
-  }
+  },
+  customIds: ["menu", "previous", "next", "submit"]
 });

--- a/src/commands/groups.ts
+++ b/src/commands/groups.ts
@@ -5,6 +5,7 @@ interface ActiveInteractions {
   [messageId: string]: {
     selectedRoleIds: string[];
     latestActionTime: number;
+    memberId: string;
   }
 }
 
@@ -213,7 +214,8 @@ new Command({
 
           activeInteractions[followup.id] = {
             latestActionTime: new Date().getTime(),
-            selectedRoleIds: []
+            selectedRoleIds: [],
+            memberId: member.id
           };
           break;
 
@@ -262,7 +264,10 @@ new Command({
     } else if (interaction.type === 3) {
 
       // This is a component interaction, so the menu is open.
+      // Make sure the interaction is from the original member.
       const originalMessage: Message = interaction.message;
+      const interactionCache = activeInteractions[originalMessage.id];
+      if (interactionCache?.memberId !== interaction.member?.id) return;
 
       // Check if the member wants to change the page or submit.
       const {custom_id}: {custom_id: string} = interaction.data;
@@ -279,7 +284,7 @@ new Command({
           // Iterate through the roles, and start on the new page number.
           let selectMenuOptions: SelectMenuOptions[] = [];
           let canGoForward: boolean = false;
-          const selectedRoleIds = activeInteractions[originalMessage.id]?.selectedRoleIds;
+          const selectedRoleIds = interactionCache?.selectedRoleIds;
           if (!selectedRoleIds) {
 
             await originalMessage.delete();

--- a/src/commands/groups.ts
+++ b/src/commands/groups.ts
@@ -123,10 +123,19 @@ new Command({
 
       }
 
-      const baseRole: string | number | boolean | undefined = subCommand.options?.find((option) => option.name === "base")?.value;
-      if (!baseRole && subCommand.name !== "list") {
+      const baseRoleId: string | number | boolean | undefined = subCommand.options?.find((option) => option.name === "base")?.value;
+      if (!baseRoleId && subCommand.name !== "list") {
         
         await interaction.createFollowup("You didn't give me a role to work with!");
+        return;
+
+      }
+
+      // Check if the base role is higher than the bot's highest role.
+      const baseRole = baseRoleId ? guild.roles.find((possibleRole) => possibleRole.id === baseRoleId) : undefined;
+      if (baseRole && baseRole.position >= highestRolePosition) {
+
+        await interaction.createFollowup("That role is higher or the same as my highest role, so I can't give that role to others.");
         return;
 
       }
@@ -157,7 +166,7 @@ new Command({
           }
 
           const followup: Message = await interaction.createFollowup({
-            content: `What roles do you want to associate with <@&${baseRole}>?`,
+            content: `What roles do you want to associate with <@&${baseRoleId}>?`,
             components: [
               {
                 type: 1, 
@@ -224,7 +233,7 @@ new Command({
         case "delete": {
 
           // Try to delete the base from the database.
-          const {deletedCount} = await collections.roleGroups.deleteOne({baseRoleId: baseRole});
+          const {deletedCount} = await collections.roleGroups.deleteOne({baseRoleId});
           
           // Tell the member.
           await interaction.createFollowup(deletedCount > 0 ? "Done." : "I don't have that base role in my records.");

--- a/src/commands/groups.ts
+++ b/src/commands/groups.ts
@@ -1,5 +1,14 @@
-import { Role } from "eris";
+import { InteractionDataOptionsSubCommand, Role, SelectMenuOptions } from "eris";
 import { Command } from "../commands.js";
+
+interface MenuDataProperties {
+  [guildId: string]: {
+    page: number;
+    selectedRoles: Role[];
+  }
+}
+
+const menuData: MenuDataProperties = {};
 
 new Command({
   name: "groups",
@@ -53,6 +62,23 @@ new Command({
 
     }
 
+    // Verify that we have a base role.
+    const subCommand = interaction.data.options?.find((option) => option.type === 1) as InteractionDataOptionsSubCommand;
+    if (!subCommand) {
+
+      await interaction.createFollowup("Couldn't find sub-command.");
+      return;
+
+    }
+
+    const baseRole = subCommand.options?.find((option) => option.name === "base")?.value;
+    if (!baseRole) {
+      
+      await interaction.createFollowup("You didn't give me a role to work with!");
+      return;
+
+    }
+
     // Make sure they have permission to manage roles.
     if (!member.permissions.has("manageRoles")) {
 
@@ -61,13 +87,88 @@ new Command({
 
     }
 
-    // Present the list of server roles to them.
-    const selectedRoles: Role[] = [];
-    while (!selectedRoles[0]) {
+    // Make sure there is at least one role in the guild.
+    let roles = guild.roles.filter(() => true);
+    if (roles.length === 0) {
+
+      await interaction.createFollowup("There aren't any roles in this server!");
+      return;
 
     }
-    const {roles} = guild;
 
+    // Present the roles to the user.
+    let selectMenuOptions: SelectMenuOptions[] = [];
+    for (let i = 0; roles.length >= i; i++) {
+
+      const {name, id} = roles[i];
+      selectMenuOptions[i] = {
+        label: name,
+        value: id
+      };
+
+      if (selectMenuOptions.length === 25) break;
+
+    }
+
+    await interaction.createFollowup({
+      content: `What roles do you want to associate with <@&${baseRole}>?`,
+      embeds: [
+        {
+          description: "As you select roles, I'll add them to this list!"
+        }
+      ],
+      components: [
+        {
+          type: 1, 
+          components: [
+            {
+              type: 3,
+              custom_id: "menu-test",
+              options: selectMenuOptions,
+              min_values: 1,
+              max_values: 25
+            }
+          ]
+        },
+        {
+          type: 1,
+          components: [
+            {
+              type: 2,
+              label: "Previous page",
+              style: 2,
+              custom_id: "previous",
+              disabled: true
+            },
+            {
+              type: 2,
+              label: "Page 1",
+              style: 2,
+              custom_id: "submit",
+              disabled: true
+            },
+            {
+              type: 2,
+              label: "Next page",
+              style: 2,
+              custom_id: "next",
+              disabled: true
+            }
+          ]
+        },
+        {
+          type: 1,
+          components: [
+            {
+              type: 2,
+              label: "Create role group",
+              style: 2,
+              custom_id: "submit"
+            }
+          ]
+        }
+      ]
+    });
 
   }
 });

--- a/src/commands/groups.ts
+++ b/src/commands/groups.ts
@@ -123,7 +123,7 @@ new Command({
       }
 
       const baseRole: string | number | boolean | undefined = subCommand.options?.find((option) => option.name === "base")?.value;
-      if (!baseRole) {
+      if (!baseRole && subCommand.name !== "list") {
         
         await interaction.createFollowup("You didn't give me a role to work with!");
         return;
@@ -226,6 +226,30 @@ new Command({
           
           // Tell the member.
           await interaction.createFollowup(deletedCount > 0 ? "Done." : "I don't have that base role in my records.");
+          break;
+
+        }
+
+        case "list": {
+
+          // Get the groups.
+          const groups = await collections.roleGroups.find({}).toArray();
+          let message = "";
+          for (let i = 0; groups.length > i; i++) {
+
+            const {baseRoleId, attachedRoleIds} = groups[i];
+            message += `<@&${baseRoleId}> -> <@&${attachedRoleIds.join(">, <@&")}>\n\n`;
+
+          }
+
+          // Tell the member.
+          await interaction.createFollowup(message ? {
+            embeds: [
+              {
+                description: message
+              }
+            ]
+          } : "There are no role groups in this server yet.");
           break;
 
         }

--- a/src/commands/groups.ts
+++ b/src/commands/groups.ts
@@ -40,6 +40,11 @@ new Command({
           required: true
         }
       ]
+    },
+    {
+      name: "list",
+      description: "Lists all group roles of this server",
+      type: 1
     }
   ],
   action: async ({discordClient, collections, interaction}) => {
@@ -128,7 +133,7 @@ new Command({
       // Check if we're adding or removing a base role to the database.
       switch (subCommand.name) {
 
-        case "add": {
+        case "create": {
 
           // Present the roles to the user.
           let selectMenuOptions: SelectMenuOptions[] = [];
@@ -250,7 +255,13 @@ new Command({
           // Iterate through the roles, and start on the new page number.
           let selectMenuOptions: SelectMenuOptions[] = [];
           let canGoForward: boolean = false;
-          const {selectedRoleIds} = activeInteractions[originalMessage.id];
+          const selectedRoleIds = activeInteractions[originalMessage.id]?.selectedRoleIds;
+          if (!selectedRoleIds) {
+
+            await originalMessage.delete();
+            return;
+
+          }
           for (let i = (newPageNumber - 1) * 24; roles.length > i; i++) {
 
             if (selectMenuOptions.length === 25) {
@@ -374,7 +385,10 @@ new Command({
             {upsert: true}
           );
 
-          // And we're done!
+          // Delete the interaction from the bot's memory.
+          delete activeInteractions[originalMessage.id];
+
+          // Tell the member that we're finished!
           await originalMessage.edit({
             content: `Attached the following roles to <@&${baseRoleId}>: <@&${selectedRoleIds.join(">, <@&")}>`,
             embeds: [],

--- a/src/commands/roles.ts
+++ b/src/commands/roles.ts
@@ -1,236 +1,240 @@
-import { Client, CommandInteraction, InteractionDataOptionsSubCommand } from "eris";
+import { Client, CommandInteraction, ComponentInteraction, InteractionDataOptionsSubCommand } from "eris";
 import { Collection } from "mongodb";
 import { Command, CommandActionProperties } from "../commands.js";
 
 // roleType: 0 (reaction), 1 (default), 2 (self)
-async function setupRole(discordClient: Client, interaction: CommandInteraction, collections: {[name: string]: Collection}, roleType: number): Promise<void> {
+async function setupRole(discordClient: Client, interaction: CommandInteraction | ComponentInteraction, collections: {[name: string]: Collection}, roleType: number): Promise<void> {
 
-  // Verify that we're in a text channel.
-  if (!("guild" in interaction.channel)) {
-    
-    await interaction.createFollowup("You can only run this command in a guild!");
-    return;
+  if (interaction.type === 2) {
 
-  }
-
-  // Verify the guild member.
-  const {guild} = interaction.channel;
-  const member = guild.members.find(possibleMember => possibleMember.id === interaction.member?.user.id);
-  if (!member) {
-    
-    await interaction.createFollowup("I can't find you in the guild member list!");
-    return;
-
-  }
-
-  // Verify the sub-command.
-  const subCommand = interaction.data.options?.find(option => option.type === 1) as InteractionDataOptionsSubCommand;
-  if (!subCommand) {
-    
-    await interaction.createFollowup("Couldn't find sub-command.");
-    return;
-
-  }
-
-  // Verify the sub-command options.
-  const {options, name: action} = subCommand;
-  if (!options) {
-    
-    await interaction.createFollowup("Couldn't find sub-command options.");
-    return;
-
-  }
-
-  // Save the sub-command options for later.
-  const noExisting = options.find(option => option.name === "no_existing")?.value;
-  const noBots = options.find(option => option.name === "no_bots")?.value;
-  const roleId = options.find(option => option.name === "role")?.value;
-  const roleIdInvalid = typeof roleId !== "string";
-  let response;
-  
-  switch (action) {
-
-    case "add": {
-
-      // Verify the member's permissions.
-      if (!member.permissions.has("manageRoles")) {
-        
-        await interaction.createFollowup("Sorry, no can do! You don't have permission to manage roles. Did you mean `/selfroles get`?");
-        return;
-
-      }
-
-      // Verify the input values.
-      if (roleIdInvalid) {
-        
-        await interaction.createFollowup("You didn't give me a role ID to work with.");
-        return;
-
-      }
-
-      // Start up keeping track of the data we're going to insert.
-      let document: {roleId: string, type: number, channelId?: string, messageId?: string, emoji?: string} = {roleId, type: roleType};
-
-      if (roleType === 0) {
-        
-        const channelId = options.find(option => option.name === "channel")?.value;
-        const channelIdInvalid = typeof channelId !== "string";
-        const messageId = options.find(option => option.name === "message_id")?.value;
-        const messageIdInvalid = typeof messageId !== "string";
-        const emoji = options.find(option => option.name === "emoji")?.value;
-        if (channelIdInvalid || messageIdInvalid || typeof emoji !== "string") {
-
-          await interaction.createFollowup("You didn't give me an emoji to work with.");
-          return;
-
-        }
-
-        // Now let's make sure that the bot can access the message and channel.
-        let reactMessage;
-        try {
-    
-          reactMessage = await discordClient.getMessage(channelId, messageId);
-
-        } catch (err) {
-    
-          await interaction.createFollowup(`Message ${messageId} doesn't exist in <#${channelId}>`);
-          return;
-
-        }
-        
-        // Keep track of the channel and message IDs.
-        document.channelId = channelId;
-        document.messageId = messageId;
-    
-        // Let's make sure that we can use that emoji.
-        const msg = await discordClient.createMessage(interaction.channel.id, "Testing emoji accessibility...");
-        document.emoji = emoji.includes("<") ? emoji.substring(1, emoji.length - 1) : emoji;
-    
-        try {
-          
-          await reactMessage.addReaction(document.emoji);
-          await msg.delete();
-    
-        } catch (err) {
-    
-          await msg.delete();
-          await interaction.createFollowup("I couldn't add that emoji to your message! Do I have permission to react in that channel or are you just flexing your Nitro?");
-          return;
-          
-        }
-
-      }
-
-      // Update the collection.
-      await collections.autoRoles.insertOne(document);
+    // Verify that we're in a text channel.
+    if (!("guild" in interaction.channel)) {
       
-      // Check if we're adding this role to existing members.
-      let affectedMembers = 0;
-      if (roleType === 1 && !noExisting) {
+      await interaction.createFollowup("You can only run this command in a guild!");
+      return;
 
-        // Iterate through the existing members.
-        const guildMembers = guild.members.map(possibleMember => possibleMember);
-        for (let i = 0; guildMembers.length > i; i++) {
+    }
 
-          // Check if the current member doesn't have the role already, and if they're a bot.
-          const guildMember = guildMembers[i];
-          if (!guildMember.roles.find(possibleMatch => roleId === possibleMatch) && (!guildMember.bot || !noBots)) {
+    // Verify the guild member.
+    const {guild} = interaction.channel;
+    const member = guild.members.find(possibleMember => possibleMember.id === interaction.member?.user.id);
+    if (!member) {
+      
+      await interaction.createFollowup("I can't find you in the guild member list!");
+      return;
 
-            // Add the role.
-            await guildMember.addRole(roleId, "Adding default role to existing members");
+    }
+
+    // Verify the sub-command.
+    const subCommand = interaction.data.options?.find(option => option.type === 1) as InteractionDataOptionsSubCommand;
+    if (!subCommand) {
+      
+      await interaction.createFollowup("Couldn't find sub-command.");
+      return;
+
+    }
+
+    // Verify the sub-command options.
+    const {options, name: action} = subCommand;
+    if (!options) {
+      
+      await interaction.createFollowup("Couldn't find sub-command options.");
+      return;
+
+    }
+
+    // Save the sub-command options for later.
+    const noExisting = options.find(option => option.name === "no_existing")?.value;
+    const noBots = options.find(option => option.name === "no_bots")?.value;
+    const roleId = options.find(option => option.name === "role")?.value;
+    const roleIdInvalid = typeof roleId !== "string";
+    let response;
+    
+    switch (action) {
+
+      case "add": {
+
+        // Verify the member's permissions.
+        if (!member.permissions.has("manageRoles")) {
+          
+          await interaction.createFollowup("Sorry, no can do! You don't have permission to manage roles. Did you mean `/selfroles get`?");
+          return;
+
+        }
+
+        // Verify the input values.
+        if (roleIdInvalid) {
+          
+          await interaction.createFollowup("You didn't give me a role ID to work with.");
+          return;
+
+        }
+
+        // Start up keeping track of the data we're going to insert.
+        let document: {roleId: string, type: number, channelId?: string, messageId?: string, emoji?: string} = {roleId, type: roleType};
+
+        if (roleType === 0) {
+          
+          const channelId = options.find(option => option.name === "channel")?.value;
+          const channelIdInvalid = typeof channelId !== "string";
+          const messageId = options.find(option => option.name === "message_id")?.value;
+          const messageIdInvalid = typeof messageId !== "string";
+          const emoji = options.find(option => option.name === "emoji")?.value;
+          if (channelIdInvalid || messageIdInvalid || typeof emoji !== "string") {
+
+            await interaction.createFollowup("You didn't give me an emoji to work with.");
+            return;
+
+          }
+
+          // Now let's make sure that the bot can access the message and channel.
+          let reactMessage;
+          try {
+      
+            reactMessage = await discordClient.getMessage(channelId, messageId);
+
+          } catch (err) {
+      
+            await interaction.createFollowup(`Message ${messageId} doesn't exist in <#${channelId}>`);
+            return;
+
+          }
+          
+          // Keep track of the channel and message IDs.
+          document.channelId = channelId;
+          document.messageId = messageId;
+      
+          // Let's make sure that we can use that emoji.
+          const msg = await discordClient.createMessage(interaction.channel.id, "Testing emoji accessibility...");
+          document.emoji = emoji.includes("<") ? emoji.substring(1, emoji.length - 1) : emoji;
+      
+          try {
             
-            // Keep track of the affected member count.
-            affectedMembers++;
+            await reactMessage.addReaction(document.emoji);
+            await msg.delete();
+      
+          } catch (err) {
+      
+            await msg.delete();
+            await interaction.createFollowup("I couldn't add that emoji to your message! Do I have permission to react in that channel or are you just flexing your Nitro?");
+            return;
+            
+          }
+
+        }
+
+        // Update the collection.
+        await collections.autoRoles.insertOne(document);
+        
+        // Check if we're adding this role to existing members.
+        let affectedMembers = 0;
+        if (roleType === 1 && !noExisting) {
+
+          // Iterate through the existing members.
+          const guildMembers = guild.members.map(possibleMember => possibleMember);
+          for (let i = 0; guildMembers.length > i; i++) {
+
+            // Check if the current member doesn't have the role already, and if they're a bot.
+            const guildMember = guildMembers[i];
+            if (!guildMember.roles.find(possibleMatch => roleId === possibleMatch) && (!guildMember.bot || !noBots)) {
+
+              // Add the role.
+              await guildMember.addRole(roleId, "Adding default role to existing members");
+              
+              // Keep track of the affected member count.
+              affectedMembers++;
+
+            }
 
           }
 
         }
 
-      }
-
-      // Everything is OK!
-      await interaction.createFollowup(`Role added! ${roleType === 1 && affectedMembers > 0 ? ` Gave the role to ${affectedMembers} existing members too.` : ""}`);
-      return;
-
-    }
-
-    case "get": {
-
-      // Check if role exists
-      const role = await collections.autoRoles.findOne({roleId, type: 2});
-      if (guild.roles.find(possibleRole => possibleRole.id === roleId) && role) {
-
-        await member.addRole(role.roleId, "Asked for it");
-        await interaction.createFollowup("It's yours, my friend.");
+        // Everything is OK!
+        await interaction.createFollowup(`Role added! ${roleType === 1 && affectedMembers > 0 ? ` Gave the role to ${affectedMembers} existing members too.` : ""}`);
         return;
 
       }
 
-      await interaction.createFollowup("That role isn't on the table!");
-      return;
+      case "get": {
 
-    }
-    
-    case "list": {
-
-      const roles = await collections.autoRoles.find({type: roleType}).toArray();
-      let descRoles = "";
-
-      for (let i = 0; roles.length > i; i++) {
-          
         // Check if role exists
-        const guildRole = guild.roles.find(possibleRole => possibleRole.id === roles[i].roleId);
+        const role = await collections.autoRoles.findOne({roleId, type: 2});
+        if (guild.roles.find(possibleRole => possibleRole.id === roleId) && role) {
 
-        if (guildRole) {
-
-          const roleIcon = roles[i].emoji && roles[i].emoji.includes(":") ? "<" + roles[i].emoji + ">" : roles[i].emoji || "🔖";
-          descRoles = descRoles + (i !== 0 ? "\n" : "") + roleIcon + " **<@&" + guildRole.id + ">**" + (roleType === 0 ? " [[Attachment]](https://discord.com/channels/" + guild.id + "/" + roles[i].channelId + "/" + roles[i].messageId + ")" : "");
-
-        } else {
-
-          // Remove the role from the collection.
-          await collections.autoRoles.deleteOne({type: roleType, roleId: roles[i].roleId});
+          await member.addRole(role.roleId, "Asked for it");
+          await interaction.createFollowup("It's yours, my friend.");
+          return;
 
         }
-        
+
+        await interaction.createFollowup("That role isn't on the table!");
+        return;
+
       }
+      
+      case "list": {
 
-      response = {
-        content: descRoles !== "" ? (roleType === 2 ? "All members can get these roles at the moment:" : (
-          roleType === 1 ? "Here are the roles I'm giving the new members now:" : (
-            roleType === 0 ? "Here are the current reaction roles:" : "If returning members had these roles before they left, I'll give them back:"
-          )
-        )) : "There aren't any roles I'm giving at the moment.",
-        embeds: descRoles !== "" ? [{
-          description: descRoles
-        }] : undefined
-      };
-      await interaction.createFollowup(response);
-      return;
+        const roles = await collections.autoRoles.find({type: roleType}).toArray();
+        let descRoles = "";
 
-    }
+        for (let i = 0; roles.length > i; i++) {
+            
+          // Check if role exists
+          const guildRole = guild.roles.find(possibleRole => possibleRole.id === roles[i].roleId);
 
-    case "delete": {
+          if (guildRole) {
 
-      // Verify that the user can manage roles.
-      if (!member.permissions.has("manageRoles")) {
+            const roleIcon = roles[i].emoji && roles[i].emoji.includes(":") ? "<" + roles[i].emoji + ">" : roles[i].emoji || "🔖";
+            descRoles = descRoles + (i !== 0 ? "\n" : "") + roleIcon + " **<@&" + guildRole.id + ">**" + (roleType === 0 ? " [[Attachment]](https://discord.com/channels/" + guild.id + "/" + roles[i].channelId + "/" + roles[i].messageId + ")" : "");
 
-        await interaction.createFollowup("Sorry, no can do! You don't have permission to manage roles. Did you mean `/selfroles get`?");
+          } else {
+
+            // Remove the role from the collection.
+            await collections.autoRoles.deleteOne({type: roleType, roleId: roles[i].roleId});
+
+          }
+          
+        }
+
+        response = {
+          content: descRoles !== "" ? (roleType === 2 ? "All members can get these roles at the moment:" : (
+            roleType === 1 ? "Here are the roles I'm giving the new members now:" : (
+              roleType === 0 ? "Here are the current reaction roles:" : "If returning members had these roles before they left, I'll give them back:"
+            )
+          )) : "There aren't any roles I'm giving at the moment.",
+          embeds: descRoles !== "" ? [{
+            description: descRoles
+          }] : undefined
+        };
+        await interaction.createFollowup(response);
         return;
 
       }
 
-      // Delete the role.
-      await collections.autoRoles.deleteOne({type: roleType, roleId});
+      case "delete": {
 
-      // Tell the user that we're finished.
-      await interaction.createFollowup("Done!");
-      return;
+        // Verify that the user can manage roles.
+        if (!member.permissions.has("manageRoles")) {
+
+          await interaction.createFollowup("Sorry, no can do! You don't have permission to manage roles. Did you mean `/selfroles get`?");
+          return;
+
+        }
+
+        // Delete the role.
+        await collections.autoRoles.deleteOne({type: roleType, roleId});
+
+        // Tell the user that we're finished.
+        await interaction.createFollowup("Done!");
+        return;
+
+      }
+
+      default:
+        break;
 
     }
-
-    default:
-      break;
 
   }
 

--- a/src/commands/roles.ts
+++ b/src/commands/roles.ts
@@ -3,12 +3,13 @@ import { Collection } from "mongodb";
 import { Command, CommandActionProperties } from "../commands.js";
 
 // roleType: 0 (reaction), 1 (default), 2 (self)
-async function setupRole(discordClient: Client, interaction: CommandInteraction, collections: {[name: string]: Collection}, roleType: number) {
+async function setupRole(discordClient: Client, interaction: CommandInteraction, collections: {[name: string]: Collection}, roleType: number): Promise<void> {
 
   // Verify that we're in a text channel.
   if (!("guild" in interaction.channel)) {
     
-    return await interaction.createFollowup("You can only run this command in a guild!");
+    await interaction.createFollowup("You can only run this command in a guild!");
+    return;
 
   }
 
@@ -17,7 +18,8 @@ async function setupRole(discordClient: Client, interaction: CommandInteraction,
   const member = guild.members.find(possibleMember => possibleMember.id === interaction.member?.user.id);
   if (!member) {
     
-    return await interaction.createFollowup("I can't find you in the guild member list!");
+    await interaction.createFollowup("I can't find you in the guild member list!");
+    return;
 
   }
 
@@ -25,7 +27,8 @@ async function setupRole(discordClient: Client, interaction: CommandInteraction,
   const subCommand = interaction.data.options?.find(option => option.type === 1) as InteractionDataOptionsSubCommand;
   if (!subCommand) {
     
-    return await interaction.createFollowup("Couldn't find sub-command.");
+    await interaction.createFollowup("Couldn't find sub-command.");
+    return;
 
   }
 
@@ -33,7 +36,8 @@ async function setupRole(discordClient: Client, interaction: CommandInteraction,
   const {options, name: action} = subCommand;
   if (!options) {
     
-    return await interaction.createFollowup("Couldn't find sub-command options.");
+    await interaction.createFollowup("Couldn't find sub-command options.");
+    return;
 
   }
 
@@ -51,14 +55,16 @@ async function setupRole(discordClient: Client, interaction: CommandInteraction,
       // Verify the member's permissions.
       if (!member.permissions.has("manageRoles")) {
         
-        return await interaction.createFollowup("Sorry, no can do! You don't have permission to manage roles. Did you mean `/selfroles get`?");
+        await interaction.createFollowup("Sorry, no can do! You don't have permission to manage roles. Did you mean `/selfroles get`?");
+        return;
 
       }
 
       // Verify the input values.
       if (roleIdInvalid) {
         
-        return await interaction.createFollowup("You didn't give me a role ID to work with.");
+        await interaction.createFollowup("You didn't give me a role ID to work with.");
+        return;
 
       }
 
@@ -74,7 +80,8 @@ async function setupRole(discordClient: Client, interaction: CommandInteraction,
         const emoji = options.find(option => option.name === "emoji")?.value;
         if (channelIdInvalid || messageIdInvalid || typeof emoji !== "string") {
 
-          return await interaction.createFollowup("You didn't give me an emoji to work with.");
+          await interaction.createFollowup("You didn't give me an emoji to work with.");
+          return;
 
         }
 
@@ -86,8 +93,9 @@ async function setupRole(discordClient: Client, interaction: CommandInteraction,
 
         } catch (err) {
     
-          return await interaction.createFollowup(`Message ${messageId} doesn't exist in <#${channelId}>`);
-    
+          await interaction.createFollowup(`Message ${messageId} doesn't exist in <#${channelId}>`);
+          return;
+
         }
         
         // Keep track of the channel and message IDs.
@@ -106,8 +114,9 @@ async function setupRole(discordClient: Client, interaction: CommandInteraction,
         } catch (err) {
     
           await msg.delete();
-          return await interaction.createFollowup("I couldn't add that emoji to your message! Do I have permission to react in that channel or are you just flexing your Nitro?");
-    
+          await interaction.createFollowup("I couldn't add that emoji to your message! Do I have permission to react in that channel or are you just flexing your Nitro?");
+          return;
+          
         }
 
       }
@@ -140,7 +149,8 @@ async function setupRole(discordClient: Client, interaction: CommandInteraction,
       }
 
       // Everything is OK!
-      return await interaction.createFollowup(`Role added! ${roleType === 1 && affectedMembers > 0 ? ` Gave the role to ${affectedMembers} existing members too.` : ""}`);
+      await interaction.createFollowup(`Role added! ${roleType === 1 && affectedMembers > 0 ? ` Gave the role to ${affectedMembers} existing members too.` : ""}`);
+      return;
 
     }
 
@@ -151,11 +161,13 @@ async function setupRole(discordClient: Client, interaction: CommandInteraction,
       if (guild.roles.find(possibleRole => possibleRole.id === roleId) && role) {
 
         await member.addRole(role.roleId, "Asked for it");
-        return await interaction.createFollowup("It's yours, my friend.");
+        await interaction.createFollowup("It's yours, my friend.");
+        return;
 
       }
 
-      return await interaction.createFollowup("That role isn't on the table!");
+      await interaction.createFollowup("That role isn't on the table!");
+      return;
 
     }
     
@@ -193,7 +205,8 @@ async function setupRole(discordClient: Client, interaction: CommandInteraction,
           description: descRoles
         }] : undefined
       };
-      return await interaction.createFollowup(response);
+      await interaction.createFollowup(response);
+      return;
 
     }
 
@@ -202,7 +215,8 @@ async function setupRole(discordClient: Client, interaction: CommandInteraction,
       // Verify that the user can manage roles.
       if (!member.permissions.has("manageRoles")) {
 
-        return await interaction.createFollowup("Sorry, no can do! You don't have permission to manage roles. Did you mean `/selfroles get`?");
+        await interaction.createFollowup("Sorry, no can do! You don't have permission to manage roles. Did you mean `/selfroles get`?");
+        return;
 
       }
 
@@ -210,7 +224,8 @@ async function setupRole(discordClient: Client, interaction: CommandInteraction,
       await collections.autoRoles.deleteOne({type: roleType, roleId});
 
       // Tell the user that we're finished.
-      return await interaction.createFollowup("Done!");
+      await interaction.createFollowup("Done!");
+      return;
 
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,10 +48,10 @@
     "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
+    "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
+    "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
     // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */


### PR DESCRIPTION
# Description
This pull request adds `/group create <base: @role>`, `/group delete <base: @role>`, and `/group list`.

# Issues resolved
* #9 

# Acceptance criteria
## /group create `<base: @role>`
* [x] When a user runs this command, the bot will verify that the interaction is in a server. If the interaction isn't in happening in a server, the bot will follow up with the user.
* [x] The bot will verify that the member has the `manageRoles` permission. If the member doesn't have this permission, the bot will follow up with the user.
* [x] The bot will send a follow up, asking the user to choose from a list of server roles. [Due to Discord restrictions](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure), the bot can only list up to 25 roles. If there are more than 25 server roles, the bot will create two buttons that allow the user to shift pages.
* [x] After the user selects the roles, they can press the green submit button, which will create and enable the role group.

## /group delete `<base: @role>`
* [x] When a user runs this command, the bot will verify that the interaction is in a server. If the interaction isn't in happening in a server, the bot will follow up with the user.
* [x] The bot will verify that the member has the `manageRoles` permission. If the member doesn't have this permission, the bot will follow up with the user.
* [x] The bot will search the database for the role group. If the bot finds the group, it will delete the document from the MongoDB collection, and then follow up with the user. Otherwise, the bot will follow up with the user, saying that the bot couldn't find the role group.

## /group list
* [x] The bot will get all group roles in a server.
* [x] Then, the bot will return the roles to the member.